### PR TITLE
Add convar for toggling functionality

### DIFF
--- a/scripting/cwx.sp
+++ b/scripting/cwx.sp
@@ -56,12 +56,12 @@ Cookie g_ItemPersistCookies[NUM_PLAYER_CLASSES][NUM_ITEMS];
 
 bool g_bForceReequipItems[MAXPLAYERS + 1];
 
+ConVar sm_cwx_enable_loadout;
+
 #include "cwx/item_config.sp"
 #include "cwx/item_entity.sp"
 #include "cwx/item_export.sp"
 #include "cwx/loadout_radio_menu.sp"
-
-ConVar sm_cwx_allow;
 
 public void OnPluginStart() {
 	LoadTranslations("cwx.phrases");
@@ -84,7 +84,8 @@ public void OnPluginStart() {
 	
 	CreateVersionConVar("cwx_version", "Custom Weapons X version.");
 	
-	sm_cwx_allow = CreateConVar("sm_cwx_allow", "1", "Enable or disable the plugin's functionality.");
+	sm_cwx_enable_loadout = CreateConVar("sm_cwx_enable_loadout", "1",
+			"Allows players to receive custom items they have selected.");
 	
 	RegAdminCmd("sm_cwx_equip", EquipItemCmd, ADMFLAG_ROOT);
 	RegAdminCmd("sm_cwx_equip_target", EquipItemCmdTarget, ADMFLAG_ROOT);
@@ -243,7 +244,7 @@ Action OnPlayerLoadoutUpdated(UserMsg msg_id, BfRead msg, const int[] players,
 }
 
 void OnPlayerLoadoutUpdatedPost(UserMsg msg_id, bool sent) {
-	if (!sm_cwx_allow.BoolValue) {
+	if (!sm_cwx_enable_loadout.BoolValue) {
 		return;
 	}
 	
@@ -289,7 +290,7 @@ void OnPlayerSpawnPost(Event event, const char[] name, bool dontBroadcast) {
  * avoid returning a nullptr.
  */
 MRESReturn OnGetLoadoutItemPost(int client, Handle hReturn, Handle hParams) {
-	if (!sm_cwx_allow.BoolValue) {
+	if (!sm_cwx_enable_loadout.BoolValue) {
 		return MRES_Ignored;
 	}
 	
@@ -370,7 +371,7 @@ public void OnClientCommandKeyValues_Post(int client, KeyValues kv) {
  * Saves the current item into the loadout for the specified class.
  */
 bool SetClientCustomLoadoutItem(int client, int playerClass, const char[] itemuid) {
-	if (!sm_cwx_allow.BoolValue) {
+	if (!sm_cwx_enable_loadout.BoolValue) {
 		PrintToChat(client, "You have equipped a custom weapon. Unfortunately, this weapon has not been given to you because custom weapons are currently disabled.");
 	}
 

--- a/scripting/cwx.sp
+++ b/scripting/cwx.sp
@@ -371,10 +371,6 @@ public void OnClientCommandKeyValues_Post(int client, KeyValues kv) {
  * Saves the current item into the loadout for the specified class.
  */
 bool SetClientCustomLoadoutItem(int client, int playerClass, const char[] itemuid) {
-	if (!sm_cwx_enable_loadout.BoolValue) {
-		PrintToChat(client, "You have equipped a custom weapon. Unfortunately, this weapon has not been given to you because custom weapons are currently disabled.");
-	}
-
 	CustomItemDefinition item;
 	if (!GetCustomItemDefinition(itemuid, item)) {
 		return false;
@@ -409,6 +405,11 @@ void UnsetClientCustomLoadoutItem(int client, int playerClass, int itemSlot) {
 void OnClientCustomLoadoutItemModified(int client, int modifiedClass) {
 	if (view_as<int>(TF2_GetPlayerClass(client)) != modifiedClass) {
 		// do nothing if the loadout for the current class wasn't modified
+		return;
+	}
+	
+	if (!sm_cwx_enable_loadout.BoolValue) {
+		// do nothing if user selections are disabled
 		return;
 	}
 	

--- a/scripting/cwx/loadout_radio_menu.sp
+++ b/scripting/cwx/loadout_radio_menu.sp
@@ -200,8 +200,12 @@ static int OnLoadoutSlotMenuEvent(Menu menu, MenuAction action, int param1, int 
 			
 			SetGlobalTransTarget(client);
 			
-			char buffer[64];
+			char buffer[192];
 			FormatEx(buffer, sizeof(buffer), "Custom Weapons X");
+			
+			if (!sm_cwx_enable_loadout.BoolValue) {
+				Format(buffer, sizeof(buffer), "%s\n%t", buffer, "CustomItemsUnavailable");
+			}
 			
 			panel.SetTitle(buffer);
 			

--- a/translations/cwx.phrases.txt
+++ b/translations/cwx.phrases.txt
@@ -929,4 +929,8 @@
 	{
 		"en" "[No custom item]"
 	}
+	"CustomItemsUnavailable"
+	{
+		"en" "(Custom items are currently disabled by the server operator.)"
+	}
 }


### PR DESCRIPTION
The code in this pull request is pretty shoddy but I think you'll understand what I'm trying to do here. Players should still be able to look through the Custom Weapons X menu and equip weapons they'd like to use, the plugin just won't equip anything onto them unless the convar is on. This means that if the plugin needs to be turned on, the convar can be toggled and then the round can be restarted by a different plugin. Feel free to change anything about the code, especially since it desperately needs optimising.