### PR TITLE
Added CWX_GetItemUIDFromEntity function

### DIFF
--- a/scripting/cwx.sp
+++ b/scripting/cwx.sp
@@ -235,14 +235,14 @@ int Native_GetItemUIDFromEntity(Handle plugin, int argc) {
 	}
 	
 	int maxlen = GetNativeCell(3);
-	char buffer[maxlen];
-	TF2Attrib_HookValueString("", non_economy, entity, buffer, sizeof(buffer));
+	char[] buffer = new char[maxlen];
+	TF2Attrib_HookValueString("", "non_economy", entity, buffer, maxlen);
 	
 	if (strcmp(buffer, "") == 0) {
 		return false;
 	}
 	
-	SetNativeString(2, buffer, sizeof(buffer));
+	SetNativeString(2, buffer, maxlen);
 	return true;
 }
 

--- a/scripting/cwx.sp
+++ b/scripting/cwx.sp
@@ -233,7 +233,7 @@ int Native_IsItemUIDValid(Handle plugin, int argc) {
 int Native_GetItemUIDFromEntity(Handle plugin, int argc) {
 	int entity = GetNativeCell(1);
 	
-	if (!IsValidEntity(entity) || !HasEntProp(entity, Prop_Send, "m_iItemDefinitionIndex")) {
+	if (!IsValidEntity(entity) || !HasEntProp(entity, Prop_Send, "m_AttributeList")) {
 		LogError("Tried to get UID from invalid entity %i", entity);
 		return false;
 	}

--- a/scripting/cwx.sp
+++ b/scripting/cwx.sp
@@ -50,9 +50,11 @@ public Plugin myinfo = {
 // otherwise it'll warn on array-based enumstruct
 #define NUM_PLAYER_CLASSES 10
 
-// we're using the "random drop line item unusual list" attribute as a dumping attribute to store the UID onto the item in an attribute
-// it's kinda icky and if anyone else happened to get the same idea it'd be bad, but it's the best we've got without trying TOO hard
-#define UID_ATTRIBUTE "random drop line item unusual list"
+// we're using the "random drop line item unusual list" attribute as a dumping attribute to
+// store the UID onto the item in an attribute (ensuring that it persists across weapon drops) -
+// it's kinda icky and if anyone else happened to get the same idea it'd be bad, but it's the
+// best we've got without trying TOO hard
+#define ATTRIB_NAME_CUSTOM_UID "random drop line item unusual list"
 
 bool g_bRetrievedLoadout[MAXPLAYERS + 1];
 
@@ -234,20 +236,21 @@ int Native_GetItemUIDFromEntity(Handle plugin, int argc) {
 	int entity = GetNativeCell(1);
 	
 	if (!IsValidEntity(entity) || !HasEntProp(entity, Prop_Send, "m_AttributeList")) {
-		LogError("Tried to get UID from invalid entity %i", entity);
+		ThrowNativeError(SP_ERROR_NATIVE, "Entity %d is invalid or not an item", entity);
 		return false;
 	}
 	
-	Address result = TF2Attrib_GetByName(entity, UID_ATTRIBUTE);
-	
+	// only pull the value from the runtime attribute list
+	Address result = TF2Attrib_GetByName(entity, ATTRIB_NAME_CUSTOM_UID);
 	if (!result) {
 		return false;
-    }
+	}
 	
 	any rawValue = TF2Attrib_GetValue(result);
 	
 	int maxlen = GetNativeCell(3);
 	char[] buffer = new char[maxlen];
+	
 	TF2Attrib_UnsafeGetStringValue(rawValue, buffer, maxlen);
 	
 	if (strcmp(buffer, "") == 0) {

--- a/scripting/cwx.sp
+++ b/scripting/cwx.sp
@@ -76,6 +76,7 @@ public APLRes AskPluginLoad2(Handle self, bool late, char[] error, int maxlen) {
 	CreateNative("CWX_SetPlayerLoadoutItem", Native_SetPlayerLoadoutItem);
 	CreateNative("CWX_EquipPlayerItem", Native_EquipPlayerItem);
 	CreateNative("CWX_IsItemUIDValid", Native_IsItemUIDValid);
+	CreateNative("CWX_GetItemUIDFromEntity", Native_GetItemUIDFromEntity);
 	
 	return APLRes_Success;
 }
@@ -222,6 +223,27 @@ int Native_IsItemUIDValid(Handle plugin, int argc) {
 	
 	CustomItemDefinition item;
 	return GetCustomItemDefinition(itemuid, item);
+}
+
+// bool CWX_GetItemUIDFromEntity(int entity, char[] buffer, int maxlen);
+int Native_GetItemUIDFromEntity(Handle plugin, int argc) {
+	int entity = GetNativeCell(1);
+	
+	if (!IsValidEntity(entity) || !HasEntProp(entity, Prop_Send, "m_iItemDefinitionIndex")) {
+		LogError("Tried to get UID from invalid entity %i", entity);
+		return false;
+	}
+	
+	int maxlen = GetNativeCell(3);
+	char buffer[maxlen];
+	TF2Attrib_HookValueString("", non_economy, entity, buffer, sizeof(buffer));
+	
+	if (strcmp(buffer, "") == 0) {
+		return false;
+	}
+	
+	SetNativeString(2, buffer, sizeof(buffer));
+	return true;
 }
 
 int s_LastUpdatedClient;

--- a/scripting/cwx.sp
+++ b/scripting/cwx.sp
@@ -50,6 +50,10 @@ public Plugin myinfo = {
 // otherwise it'll warn on array-based enumstruct
 #define NUM_PLAYER_CLASSES 10
 
+// we're using the "random drop line item unusual list" attribute as a dumping attribute to store the UID onto the item in an attribute
+// it's kinda icky and if anyone else happened to get the same idea it'd be bad, but it's the best we've got without trying TOO hard
+#define UID_ATTRIBUTE "random drop line item unusual list"
+
 bool g_bRetrievedLoadout[MAXPLAYERS + 1];
 
 Cookie g_ItemPersistCookies[NUM_PLAYER_CLASSES][NUM_ITEMS];
@@ -234,9 +238,17 @@ int Native_GetItemUIDFromEntity(Handle plugin, int argc) {
 		return false;
 	}
 	
+	Address result = TF2Attrib_GetByName(entity, UID_ATTRIBUTE);
+	
+	if (!result) {
+		return false;
+    }
+	
+	any rawValue = TF2Attrib_GetValue(result);
+	
 	int maxlen = GetNativeCell(3);
 	char[] buffer = new char[maxlen];
-	TF2Attrib_HookValueString("", "non_economy", entity, buffer, maxlen);
+	TF2Attrib_UnsafeGetStringValue(rawValue, buffer, maxlen);
 	
 	if (strcmp(buffer, "") == 0) {
 		return false;

--- a/scripting/cwx/item_config.sp
+++ b/scripting/cwx/item_config.sp
@@ -303,10 +303,7 @@ int EquipCustomItem(int client, const CustomItemDefinition item) {
 	}
 	
 	// add a stinky attribute that holds the item's uid
-	// this allows plugins to determine if the item is custom by seeing if it has the "non economy" attribute
-	// the uid is stored as the value, so it can also determine which custom item it is
-	// could cause problems if anyone else decides to use the "non economy" attribute in some similar fashion, though...
-	TF2Attrib_SetFromStringValue(itemEntity, "non economy", item.uid);
+	TF2Attrib_SetFromStringValue(itemEntity, UID_ATTRIBUTE, item.uid);
 	
 	// apply attributes for Custom Attributes
 	if (item.customAttributes) {

--- a/scripting/cwx/item_config.sp
+++ b/scripting/cwx/item_config.sp
@@ -303,7 +303,8 @@ int EquipCustomItem(int client, const CustomItemDefinition item) {
 	}
 	
 	// add a stinky attribute that holds the item's uid
-	TF2Attrib_SetFromStringValue(itemEntity, UID_ATTRIBUTE, item.uid);
+	// this value is read with CWX_GetItemUIDFromEntity
+	TF2Attrib_SetFromStringValue(itemEntity, ATTRIB_NAME_CUSTOM_UID, item.uid);
 	
 	// apply attributes for Custom Attributes
 	if (item.customAttributes) {

--- a/scripting/include/cwx.inc
+++ b/scripting/include/cwx.inc
@@ -51,6 +51,14 @@ native int CWX_EquipPlayerItem(int client, const char[] uid);
  */
 native bool CWX_IsItemUIDValid(const char[] uid);
 
+/**
+ * Retrieves an existing weapon's uid into the buffer.
+ *
+ * @return    True if the item has a uid, False if not.
+ * @error     Entity is invalid or incapable of being a custom item.
+ */
+native bool CWX_GetItemUIDFromEntity(int entity, char[] buffer, int maxlen);
+
 public SharedPlugin __pl_custom_weapons_x = {
 	name = "cwx",
 	file = "cwx.smx",

--- a/scripting/include/cwx.inc
+++ b/scripting/include/cwx.inc
@@ -52,10 +52,11 @@ native int CWX_EquipPlayerItem(int client, const char[] uid);
 native bool CWX_IsItemUIDValid(const char[] uid);
 
 /**
- * Retrieves an existing weapon's uid into the buffer.
+ * Retrieves an item's UID, if one exists.
  *
- * @return    True if the item has a uid, False if not.
- * @error     Entity is invalid or incapable of being a custom item.
+ * @return    True if the item has an associated UID, false if not.  (Note that the item UID is
+ *            not tested for validity within the plugin's known items.)
+ * @error     Entity is not an item.
  */
 native bool CWX_GetItemUIDFromEntity(int entity, char[] buffer, int maxlen);
 


### PR DESCRIPTION
Allows plugins to determine whether an item is custom or not and retrieve its UID if necessary