### PR TITLE
Proper way to strip static attributes

### DIFF
--- a/scripting/cwx/item_config.sp
+++ b/scripting/cwx/item_config.sp
@@ -319,35 +319,35 @@ int EquipCustomItem(int client, const CustomItemDefinition item) {
 
 		for(int i = 0; i < 16; i++)
 		{
-			if(staticAttribs[i] == 0)
+			if(staticAttribs[i] == 0) {
 				continue;
+			}
 
 			// Probably overkill
 			if(staticAttribs[i] == 796 || staticAttribs[i] == 724 || staticAttribs[i] == 817 || staticAttribs[i] == 834 
-				|| staticAttribs[i] == 745 || staticAttribs[i] == 731 || staticAttribs[i] == 746)
+				|| staticAttribs[i] == 745 || staticAttribs[i] == 731 || staticAttribs[i] == 746) {
 				continue;
+			}
 
 			// "stored_as_integer" is absent from the attribute schema if its type is "string".
 			// TF2ED_GetAttributeDefinitionString returns false if it can't find the given string.
-			if(!TF2Econ_GetAttributeDefinitionString(staticAttribs[i], "stored_as_integer", valueType, sizeof(valueType)))
+			if(!TF2Econ_GetAttributeDefinitionString(staticAttribs[i], "stored_as_integer", valueType, sizeof(valueType))) {
 				continue;
+			}
 
 			TF2Econ_GetAttributeDefinitionString(staticAttribs[i], "description_format", valueFormat, sizeof(valueFormat));
 
 			// Since we already know what we're working with and what we're looking for, we can manually handpick
 			// the most significative chars to check if they match. Eons faster than doing StrEqual or StrContains.
 
-			if(valueFormat[9] == 'a' && valueFormat[10] == 'd') // value_is_additive & value_is_additive_percentage
-			{
+			if(valueFormat[9] == 'a' && valueFormat[10] == 'd') { // value_is_additive & value_is_additive_percentage
 				TF2Attrib_SetByDefIndex(itemEntity, staticAttribs[i], 0.0);
 			}
 			else if((valueFormat[9] == 'i' && valueFormat[18] == 'p')
-				|| (valueFormat[9] == 'p' && valueFormat[10] == 'e')) // value_is_percentage & value_is_inverted_percentage
-			{
+				|| (valueFormat[9] == 'p' && valueFormat[10] == 'e')) { // value_is_percentage & value_is_inverted_percentage
 				TF2Attrib_SetByDefIndex(itemEntity, staticAttribs[i], 1.0);
 			}
-			else if(valueFormat[9] == 'o' && valueFormat[10] == 'r') // value_is_or
-			{
+			else if(valueFormat[9] == 'o' && valueFormat[10] == 'r') { // value_is_or
 				TF2Attrib_SetByDefIndex(itemEntity, staticAttribs[i], 0.0);
 			}
 		}


### PR DESCRIPTION
The only way ( that we currently know of ) is to nullify the attributes rather than stripping them entirely.