### PR TITLE
Update item_entity.sp

### DIFF
--- a/scripting/cwx/item_entity.sp
+++ b/scripting/cwx/item_entity.sp
@@ -22,6 +22,9 @@ stock int TF2_CreateItem(int defindex, const char[] itemClass) {
 		
 		SetEntProp(weapon, Prop_Send, "m_iEntityQuality", 6);
 		SetEntProp(weapon, Prop_Send, "m_iEntityLevel", 1);
+
+		// if this is not toggled, then the weapon entity may not be visible
+		SetEntProp(weapon, Prop_Send, "m_bValidatedAttachedEntity", true);
 		
 		DispatchSpawn(weapon);
 	}


### PR DESCRIPTION
Now toggles `m_bValidatedAttachedEntity` in `TF2_CreateItem()`, so that the entity actually shows